### PR TITLE
Remove Proguard stripped constructor from PendingCallback

### DIFF
--- a/jobdispatcher/src/main/java/com/google/android/gms/gcm/PendingCallback.java
+++ b/jobdispatcher/src/main/java/com/google/android/gms/gcm/PendingCallback.java
@@ -43,10 +43,6 @@ public final class PendingCallback implements Parcelable {
         mBinder = in.readStrongBinder();
     }
 
-    public PendingCallback(IBinder binder) {
-        mBinder = binder;
-    }
-
     public IBinder getIBinder() {
         return mBinder;
     }

--- a/jobdispatcher/src/test/java/com/firebase/jobdispatcher/GooglePlayCallbackExtractorTest.java
+++ b/jobdispatcher/src/test/java/com/firebase/jobdispatcher/GooglePlayCallbackExtractorTest.java
@@ -74,7 +74,9 @@ public final class GooglePlayCallbackExtractorTest {
 
     @Test
     public void testExtractCallback_goodParcelable() {
-        PendingCallback pcb = new PendingCallback(new NopCallback());
+        Parcel container = Parcel.obtain();
+        container.writeStrongBinder(new NopCallback());
+        PendingCallback pcb = new PendingCallback(container);
 
         Bundle validBundle = new Bundle();
         validBundle.putParcelable("callback", pcb);

--- a/jobdispatcher/src/test/java/com/firebase/jobdispatcher/JobServiceTest.java
+++ b/jobdispatcher/src/test/java/com/firebase/jobdispatcher/JobServiceTest.java
@@ -20,6 +20,7 @@ import android.content.Intent;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.IBinder;
+import android.os.Parcel;
 
 import com.google.android.gms.gcm.PendingCallback;
 
@@ -117,7 +118,9 @@ public class JobServiceTest {
         int startId = 7;
 
         Intent executeJobIntent = new Intent(JobService.ACTION_EXECUTE);
-        executeJobIntent.putExtra("callback", new PendingCallback(mock(IBinder.class)));
+        Parcel p = Parcel.obtain();
+        p.writeStrongBinder(mock(IBinder.class));
+        executeJobIntent.putExtra("callback", new PendingCallback(p));
 
         service.onStartCommand(executeJobIntent, 0, startId);
 


### PR DESCRIPTION
The GCM client library doesn't end up using this constructor, so it gets stripped by Proguard. Remove it from our copy to prevent anyone accidentally relying on it. Also update the tests to use the Parcel-based version.