### PR TITLE
Prevent crash caused by uncaught Service not registered exception

### DIFF
--- a/jobdispatcher/src/main/java/com/firebase/jobdispatcher/ExternalReceiver.java
+++ b/jobdispatcher/src/main/java/com/firebase/jobdispatcher/ExternalReceiver.java
@@ -60,7 +60,11 @@ import com.firebase.jobdispatcher.JobService.JobResult;
 
         connection.onJobFinished(jobParameters);
         if (connection.shouldDie()) {
-            unbindService(connection);
+            try {
+                unbindService(connection);
+            } catch(IllegalArgumentException e) {
+                Log.w(TAG, e.getMessage());
+            }
             synchronized (serviceConnections) {
                 serviceConnections.remove(connection);
             }


### PR DESCRIPTION
This simply logs the "Service not registered" exception instead of allowing the application to crash.