### PR TITLE
Fix ‘replace current’ flag not being encoded

### DIFF
--- a/jobdispatcher/src/main/java/com/firebase/jobdispatcher/JobCoder.java
+++ b/jobdispatcher/src/main/java/com/firebase/jobdispatcher/JobCoder.java
@@ -49,6 +49,8 @@ import android.support.annotation.Nullable;
             jobParameters.getLifetime());
         data.putBoolean(prefix + BundleProtocol.PACKED_PARAM_RECURRING,
             jobParameters.isRecurring());
+        data.putBoolean(prefix + BundleProtocol.PACKED_PARAM_REPLACE_CURRENT,
+            jobParameters.shouldReplaceCurrent());
         data.putString(prefix + BundleProtocol.PACKED_PARAM_TAG,
             jobParameters.getTag());
         data.putString(prefix + BundleProtocol.PACKED_PARAM_SERVICE,

--- a/jobdispatcher/src/test/java/com/firebase/jobdispatcher/TestUtil.java
+++ b/jobdispatcher/src/test/java/com/firebase/jobdispatcher/TestUtil.java
@@ -107,22 +107,25 @@ public class TestUtil {
         for (String tag : TAG_COMBINATIONS) {
             for (List<Integer> constraintList : getAllConstraintCombinations()) {
                 for (boolean recurring : new boolean[]{true, false}) {
-                    for (int lifetime : LIFETIME_COMBINATIONS) {
-                        for (JobTrigger trigger : TRIGGER_COMBINATIONS) {
-                            for (Class<TestJobService> service : SERVICE_COMBINATIONS) {
-                                for (Bundle extras : getBundleCombinations()) {
-                                    for (RetryStrategy rs : RETRY_STRATEGY_COMBINATIONS) {
-                                        //noinspection WrongConstant
-                                        jobs.add(builder
-                                            .setTag(tag)
-                                            .setRecurring(recurring)
-                                            .setConstraints(toIntArray(constraintList))
-                                            .setLifetime(lifetime)
-                                            .setTrigger(trigger)
-                                            .setService(service)
-                                            .setExtras(extras)
-                                            .setRetryStrategy(rs)
-                                            .build());
+                    for (boolean replaceCurrent : new boolean[]{true, false}) {
+                        for (int lifetime : LIFETIME_COMBINATIONS) {
+                            for (JobTrigger trigger : TRIGGER_COMBINATIONS) {
+                                for (Class<TestJobService> service : SERVICE_COMBINATIONS) {
+                                    for (Bundle extras : getBundleCombinations()) {
+                                        for (RetryStrategy rs : RETRY_STRATEGY_COMBINATIONS) {
+                                            //noinspection WrongConstant
+                                            jobs.add(builder
+                                                .setTag(tag)
+                                                .setRecurring(recurring)
+                                                .setReplaceCurrent(replaceCurrent)
+                                                .setConstraints(toIntArray(constraintList))
+                                                .setLifetime(lifetime)
+                                                .setTrigger(trigger)
+                                                .setService(service)
+                                                .setExtras(extras)
+                                                .setRetryStrategy(rs)
+                                                .build());
+                                        }
                                     }
                                 }
                             }
@@ -154,6 +157,7 @@ public class TestUtil {
         assertNotNull("output", output);
 
         assertEquals("isRecurring()", input.isRecurring(), output.isRecurring());
+        assertEquals("shouldReplaceCurrent()", input.shouldReplaceCurrent(), output.shouldReplaceCurrent());
         assertEquals("getLifetime()", input.getLifetime(), output.getLifetime());
         assertEquals("getTag()", input.getTag(), output.getTag());
         assertEquals("getService()", input.getService(), output.getService());
@@ -164,7 +168,6 @@ public class TestUtil {
         assertTriggersEqual(input.getTrigger(), output.getTrigger());
         assertBundlesEqual(input.getExtras(), output.getExtras());
         assertRetryStrategiesEqual(input.getRetryStrategy(), output.getRetryStrategy());
-
     }
 
     static void assertRetryStrategiesEqual(RetryStrategy in, RetryStrategy out) {


### PR DESCRIPTION
The `replaceCurrent` flag of a `Job` is currently being ignored since the `JobCoder` is not encoding it into the `Bundle`.

This fixes #59.