### PR TITLE
Handle errors when sending task results back

### DIFF
--- a/jobdispatcher/src/main/java/com/firebase/jobdispatcher/GooglePlayReceiver.java
+++ b/jobdispatcher/src/main/java/com/firebase/jobdispatcher/GooglePlayReceiver.java
@@ -158,7 +158,7 @@ public final class GooglePlayReceiver extends ExternalReceiver {
             JobCallback callback = map.remove(js.getTag());
             if (callback != null) {
                 Log.i(TAG, "sending jobFinished for " + js.getTag() + " = " + result);
-                callback.jobFinished(result);
+                sendResultSafely(callback, result);
             }
 
             if (map.isEmpty()) {


### PR DESCRIPTION
Most of the receiver code that communicates back with Google Play
services uses the sendResultsSafely method to correctly guard against
the possibility of a RemoteException occurring. Unfortunately the
routine that returns the result at the end of execution did not. This
can cause a DeadObjectException if Google Play services dies before the
task result is sent.

Update the onJobFinished callback to use sendResultsSafely instead of
potentially crashing the client app.

Fixes #26.