### PR TITLE
Fix backoff NumberFormatException

### DIFF
--- a/testapp/src/main/java/com/firebase/jobdispatcher/testapp/JobForm.java
+++ b/testapp/src/main/java/com/firebase/jobdispatcher/testapp/JobForm.java
@@ -51,7 +51,7 @@ public class JobForm extends BaseObservable {
     }
 
     public void setInitialBackoffSecondsStr(String in) {
-        this.initialBackoffSeconds = Integer.valueOf(in, 10);
+        this.initialBackoffSeconds = convertToInt(in);
     }
 
     @Bindable
@@ -60,7 +60,7 @@ public class JobForm extends BaseObservable {
     }
 
     public void setMaximumBackoffSecondsStr(String in) {
-        this.maximumBackoffSeconds = Integer.valueOf(in, 10);
+        this.maximumBackoffSeconds = convertToInt(in);
     }
 
     public int getWinStartSeconds() {


### PR DESCRIPTION
### Fix backoff NumberFormatException

Default backoff number is 30. Delete "0" and "3". EditText is blank. Blank is a not Number.

Fixed use convertToInt method like window.