### PR TITLE
Fix NPE when jobFinished() was called before onStartJob() returns.

### DIFF
--- a/jobdispatcher/src/main/java/com/firebase/jobdispatcher/JobInvocation.java
+++ b/jobdispatcher/src/main/java/com/firebase/jobdispatcher/JobInvocation.java
@@ -194,8 +194,8 @@ import com.firebase.jobdispatcher.Constraint.JobConstraint;
     }
 
     /**
-     * @return true if the tag, the service, and the trigger of provided {@link JobInvocation} have
-     * the same values.
+     * @return true if the tag and the service of provided {@link JobInvocation} have the same
+     * values.
      */
     @Override
     public boolean equals(Object o) {
@@ -209,15 +209,13 @@ import com.firebase.jobdispatcher.Constraint.JobConstraint;
         JobInvocation jobInvocation = (JobInvocation) o;
 
         return mTag.equals(jobInvocation.mTag)
-                && mService.equals(jobInvocation.mService)
-                && mTrigger.equals(jobInvocation.mTrigger);
+                && mService.equals(jobInvocation.mService);
     }
 
     @Override
     public int hashCode() {
         int result = mTag.hashCode();
         result = 31 * result + mService.hashCode();
-        result = 31 * result + mTrigger.hashCode();
         return result;
     }
 }

--- a/jobdispatcher/src/test/java/com/firebase/jobdispatcher/JobInvocationTest.java
+++ b/jobdispatcher/src/test/java/com/firebase/jobdispatcher/JobInvocationTest.java
@@ -72,4 +72,12 @@ public class JobInvocationTest {
         assertNotEquals(jobInvocation, jobInvocationNew);
         assertNotEquals(jobInvocation.hashCode(), jobInvocationNew.hashCode());
     }
+
+    @Test
+    public void contract_hashCode_equals_triggerShouldBeIgnored() {
+        JobInvocation jobInvocation = builder.build();
+        JobInvocation periodic = builder.setTrigger(Trigger.executionWindow(0, 1)).build();
+        assertEquals(jobInvocation, periodic);
+        assertEquals(jobInvocation.hashCode(), periodic.hashCode());
+    }
 }


### PR DESCRIPTION
Fix NPE when jobFinished() was called before onStartJob() returns.
https://github.com/firebase/firebase-jobdispatcher-android/issues/104


Fix hashCode and equals for JobInvocation.
Triggers should not be checked. They are used in ExecutionDelegator by serviceConnections(SimpleArrayMap) and requests from GCM.
Because triggers are recreated on all requests, we can't use default implementation of equals and hashCode.
 Since jobs are uniquely identified by Service Name and Tag there is no sense in comparing triggers or any other attributes.