### PR TITLE
Replace support-v4 dependency with support-compat

### DIFF
--- a/jobdispatcher/build.gradle
+++ b/jobdispatcher/build.gradle
@@ -39,7 +39,7 @@ android {
 
 dependencies {
     // The main library only depends on the Android support lib
-    compile "com.android.support:support-v4:${project.ext.supportLibraryVersion}"
+    compile "com.android.support:support-compat:${project.ext.supportLibraryVersion}"
 
     def junit = 'junit:junit:4.12'
     def robolectric = 'org.robolectric:robolectric:3.3.2'


### PR DESCRIPTION
Instead of relying on the entirety of support-v4 (which includes libraries such as [media-compat](https://developer.android.com/topic/libraries/support-library/packages.html#v4-media-compat)), rely only on the `support-compat` dependency. This reduces the amount of transitive dependencies and fixes #85 