### PR TITLE
compile -> implementation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Play services is unavailable.<br>
 Add the following to your `build.gradle`'s dependencies section:
 
 ```
-compile 'com.firebase:firebase-jobdispatcher:0.8.1'
+implementation 'com.firebase:firebase-jobdispatcher:0.8.1'
 ```
 
 ### Usage


### PR DESCRIPTION
From gradle plugin 3.0, "compile" is deprecated so it would be good to use "implementation" for app developers.