### PR TITLE
Use superscript for comparison points in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ Framework [JobScheduler][] | 21          | No                     | JobScheduler
 Firebase JobDispatcher     | 9           | Yes                    | JobScheduler                    | Yes
 [evernote/android-job][]   | 14          | No<sup>[2](#fn2)</sup> | Custom                          | Yes
 
-<a name="fn1">1</a>: Refers to the methods that need to be implemented in the
+<sup><a name="fn1">1</a></sup> Refers to the methods that need to be implemented in the
 Service subclass.<br>
-<a name="fn2">2</a>: Uses AlarmManager to support API levels <= 21 if Google
+<sup><a name="fn2">2</a></sup> Uses AlarmManager to support API levels <= 21 if Google
 Play services is unavailable.<br>
 
 ## Getting started


### PR DESCRIPTION
I originally misread the second line as "[Firebase JobDispatcher] uses AlarmManager to support API levels <= 21 if Google Play services is unavailable" until I noticed the superscript for evernote/android-job.

Based on their position under "Comparisons to other libraries" and if you glance over the table, the two points, 1 and 2, read like they are features of Firebase JobDispatcher.

[This blog post](https://medium.com/@anshuljain/become-a-pro-at-scheduling-tasks-in-android-1b955f75f430) and [another one](https://android.jlelse.eu/schedule-tasks-and-jobs-intelligently-in-android-e0b0d9201777) also seemed to misread this and state that Firebase JobDispatcher defaults to AlarmManager when Google Play services in unavailable.

However, defaulting to AlarmManager is not actually supported right now (#24).  Hopefully this change makes it a little more apparent upon first glance.